### PR TITLE
remove call for non-existed method [check] on JWTAuth

### DIFF
--- a/src/JwtAuthGuard.php
+++ b/src/JwtAuthGuard.php
@@ -59,7 +59,7 @@ class JwtAuthGuard implements Guard
             return $this->user;
         }
 
-        if (! $this->jwt->getToken() || ! $this->jwt->check()) {
+        if (! $this->jwt->getToken()) {
             return null;
         }
 


### PR DESCRIPTION
Method [check] does not existed in JWTAuth instance and hence invoking this method will throw an BadMethodCallException.
