### PR TITLE
[FIX] Allow laravel 6.x or lumen 6.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php" : ">=5.5.0",
-        "illuminate/support": "~5.0"
+        "illuminate/support": ">=5.0"
     },
     "require-dev": {
         "phpunit/phpunit" : "4.*",


### PR DESCRIPTION
Fixes issue #44.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used the project.
- [ ] I have used the project briefly.
- [x] I have used the project extensively, but have not contributed previously.
- [ ] I am an active contributor to the project.

---

Also allows laravel or lumen 6. Nothing to change except composer.json (checked by going through https://laravel.com/docs/6.x/upgrade and https://lumen.laravel.com/docs/6.x/upgrade#upgrade-6.0.0)
